### PR TITLE
Reduced DB calls using SESSION

### DIFF
--- a/classes/togglelib.php
+++ b/classes/togglelib.php
@@ -292,5 +292,37 @@ class togglelib {
         }
         return $param;
     }
+
+    /**
+     * Called on page load to get the cached preference to initialise the page with
+     * Any subsequent changes are cached and updated in DB on either logout or page reload
+     *
+     * If the session cache has no value (no cache) - the cache is filled from the database
+     * else it will save the preference that is in the session cache to the database
+     *
+     * @param string $name name of the preference
+     * @return mixed|null the preference from the cache
+     */
+    public static function get_cached_preference($name) {
+        global $SESSION;
+
+        // Create object to store prefs if doesn't exist.
+        if (empty($SESSION->topcollpreferences)) {
+            $SESSION->topcollpreferences = new \stdClass();
+        }
+
+        // Is this preference already cached?
+        if (empty($SESSION->topcollpreferences->$name)) {
+            // No session cache, so load from DB into session.
+            $SESSION->topcollpreferences->$name = get_user_preferences($name);;
+        } else {
+            // Session already exists, so update the DB.
+            if (!set_user_preference($name, $SESSION->topcollpreferences->$name)) {
+                print_error('errorsettinguserpref');
+            };
+        }
+
+        return $SESSION->topcollpreferences->$name;
+    }
 }
 

--- a/format.php
+++ b/format.php
@@ -79,7 +79,7 @@ if (!empty($displaysection)) {
 
     if ($defaulttogglepersistence == 1) {
         user_preference_allow_ajax_update('topcoll_toggle_' . $course->id, PARAM_RAW);
-        $userpreference = get_user_preferences('topcoll_toggle_' . $course->id);
+        $userpreference = \format_topcoll\togglelib::get_cached_preference('topcoll_toggle_' . $course->id);
     } else {
         $userpreference = null;
     }

--- a/settopcollpref.php
+++ b/settopcollpref.php
@@ -45,9 +45,9 @@ if (!isset($USER->ajax_updatable_user_prefs[$name])) {
 $value = \format_topcoll\togglelib::required_topcoll_param('value');
 // Update.
 if ($value) {
-    if (!set_user_preference($name, $value)) {
-        print_error('errorsettinguserpref');
-    }
+    // Update in a local cache, to avoid unnecessarily calling the database
+    $SESSION->topcollpreferences->$name = $value;
+
     echo 'OK';
 } else {
     header('HTTP/1.1 406 Not Acceptable');


### PR DESCRIPTION
Plugin currently calls set_user_preferences every time a topic is toggled visible/hidden - every call to this results in a change to the DB to save the preference. This causes a lot of unnecessary DB calls for what is more or less cosmetic.

This PR modifies the plugin to store the preference in $SESSION which on page reload will save the cache to the DB.

This does have some unintended effects, e.g. if the user has multiple sessions (e.g. multiple browsers) the caches will become out of sync. However I believe this is not an issue as this is not a critical component and is just for display/cosmetic.

While it would be ideal to add hooks that save the cache to the DB for logout, navigate away from course, etc - this doesn't really seem to be possible at the moment.