### PR TITLE
Fix activity chooser template path for Moodle courseformat refactor

### DIFF
--- a/templates/local/content/cm.mustache
+++ b/templates/local/content/cm.mustache
@@ -23,7 +23,9 @@
 {{#editing}}
     {{< core_courseformat/local/content/divider}}
         {{$content}}
-            {{#activitychooserbutton}}{{> core_course/activitychooserbutton}}{{/activitychooserbutton}}
+            {{#activitychooserbutton}}
+                {{> core_courseformat/local/content/activitychooserbutton}}
+            {{/activitychooserbutton}}
         {{/content}}
     {{/ core_courseformat/local/content/divider}}
 {{/editing}}


### PR DESCRIPTION
Replace deprecated core_course/activitychooserbutton partial with
core_courseformat/local/content/activitychooserbutton following
activity chooser refactor (MDL-81767).